### PR TITLE
fix: write git index to disk

### DIFF
--- a/src/git_operations.rs
+++ b/src/git_operations.rs
@@ -66,6 +66,8 @@ impl Git {
         let parent_commit = self.find_last_commit()?;
         self.repo
             .commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent_commit])?;
+        // Make sure the tree is written to disk
+        tree.write()?;
         Ok(())
     }
 


### PR DESCRIPTION
This fixes the problem with the open git index that is still visible after commit.

Fixes #3