### PR TITLE
fix: commit signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,10 @@ regex = "1.9.1"
 toml = "0.8.12"
 tracing = "0.1.37"
 
-[dependencies.git2]
-version = "0.18.3"
-default-features = false
 
 [dev-dependencies]
 tempfile = "3.10"
+
+[dev-dependencies.git2]
+version = "0.18.3"
+default-features = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,12 +45,6 @@ impl Default for Config {
     }
 }
 
-impl Config {
-    pub fn get_file_paths(&self) -> Vec<&PathBuf> {
-        self.files.iter().map(|(path, _)| path).collect()
-    }
-}
-
 pub static WORKDIR_CONFIG_PATH: &str = "./incrementor.toml";
 
 impl Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,9 +245,6 @@ fn main() -> Result<()> {
                 }
             }
             Err(err) => {
-                if !args.dry_run {
-                    git.rollback(config.get_file_paths())?;
-                }
                 return Err(err);
             }
         }


### PR DESCRIPTION
Use a simple `std::io::Command` instead of the git2 crate for commits and tags. This also removes the rollback operation due to its faulty design.

Fixes #2